### PR TITLE
issue #796: Ошибка при создании опроса

### DIFF
--- a/profiles/drupalru/modules/inner_poll/inner_poll.module
+++ b/profiles/drupalru/modules/inner_poll/inner_poll.module
@@ -334,10 +334,21 @@ function inner_poll_form_alter(&$form, $form_state, $form_id) {
 }
 
 /**
- * Implements hook_node_validate().
+ * Implements hook_node_insert().
+ *
+ * Обработка события создания ноды.
  */
-function inner_poll_node_validate($node, $form, &$form_state) {
-  empty($node->nid) ? _add_new_poll($node) : _update_poll($node);
+function inner_poll_node_insert($node) {
+  _add_new_poll($node);
+}
+
+/**
+ * Implements hook_node_update().
+ *
+ * Обработка события обновления ноды.
+ */
+function inner_poll_node_update($node) {
+  _update_poll($node);
 }
 
 /**


### PR DESCRIPTION
#796 

Вернул хуки `_node_insert` и `_node_update` вместо `_node_validate`. 
При вызове ф-ций `_add_new_poll` и `_update_poll` используется `nid` для инсерта в таблицу, который не может быть `NULL`.

ЗЫ - обновлял с мастера.