### PR TITLE
issue #793: Пересмотреть форму регистрации нового пользователя

### DIFF
--- a/profiles/drupalru/modules/drurum/drurum.install
+++ b/profiles/drupalru/modules/drurum/drurum.install
@@ -273,3 +273,24 @@ function drurum_update_7011(&$sandbox) {
 function drurum_update_7012(&$sandbox) {
   module_enable(['mailsystem', 'mimemail', 'mimemail_action']);
 }
+
+/**
+ * Disable profile field "Security Question" and remove it data
+ */
+function drurum_update_7013() {
+  // remove data
+  db_delete('profile_value')
+  ->condition('fid', 37)
+  ->execute();
+
+  // remove field
+  db_delete('profile_field')
+  ->condition('fid', 37)
+  ->execute();
+
+  //enable reckaptcha
+  module_enable(['recaptcha']);
+
+  // disable ascii_art_captcha
+  module_disable(['ascii_art_captcha']);
+}

--- a/profiles/drupalru/modules/drurum/drurum.install
+++ b/profiles/drupalru/modules/drurum/drurum.install
@@ -277,7 +277,7 @@ function drurum_update_7012(&$sandbox) {
 /**
  * Hide profile field "Security Question"
  */
-function drurum_update_7013() {
+function drurum_update_7014() {
   // Hide field on registration
   db_update('profile_field')
   ->fields(array('register' => 0))

--- a/profiles/drupalru/modules/drurum/drurum.install
+++ b/profiles/drupalru/modules/drurum/drurum.install
@@ -275,16 +275,17 @@ function drurum_update_7012(&$sandbox) {
 }
 
 /**
- * Disable profile field "Security Question" and remove it data
+ * Hide profile field "Security Question"
  */
 function drurum_update_7013() {
-  // remove data
-  db_delete('profile_value')
+  // Hide field on registration
+  db_update('profile_field')
+  ->fields(array('register' => 0))
   ->condition('fid', 37)
   ->execute();
-
-  // remove field
-  db_delete('profile_field')
+  // Hide field in profile
+  db_update('profile_field')
+  ->fields(array('visibility' => 4))
   ->condition('fid', 37)
   ->execute();
 


### PR DESCRIPTION
#793 

Что было сделано:
1) Удалено поле "Секретный вопрос" и все его значения из БД
2) Описания полей по умолчанию для анонимов реализованы в задаче 644
3) Капча заменена на рекапчу. Этот пункт потребует настройки на проде (регистрация в гугле, если ее еще нет, вбить site id и тд)
4) Проверку отправки писем нужно делать только на проде, на деве это бессмысленно