### PR TITLE
issue #1203: Внедрить подписку на комментарии материала без написания…

### DIFF
--- a/sites/all/modules/custom/drurum/drurum.forum.inc
+++ b/sites/all/modules/custom/drurum/drurum.forum.inc
@@ -1,0 +1,105 @@
+<?php
+
+
+/**
+ * Define default flags.
+ */
+function _drurum_flag_default_flags() {
+  $flags = [];
+  $flags[DRURUM_FORUM_TOPIC_SUBSCRIBE_FLAG] = [
+    'entity_type' => 'node',
+    'title' => 'Forum topic subscribe',
+    'global' => FALSE,
+    'types' => [
+      1 => 'blog',
+    ],
+    'flag_short' => 'Subscribe this',
+    'flag_long' => 'Add forum topic to your subscribe',
+    'flag_message' => 'This forum has been added to your subscribe',
+    'unflag_short' => 'Unsubscribe this',
+    'unflag_long' => 'Remove this forum topic from your subscribes',
+    'unflag_message' => 'This forum has been removed from your subscribes',
+    'unflag_denied_text' => '',
+    'link_type' => 'toggle',
+    'weight' => 0,
+    'show_in_links' => [
+      'full' => TRUE,
+      'token' => FALSE,
+    ],
+    'show_as_field' => FALSE,
+    'show_on_form' => FALSE,
+    'access_author' => '',
+    'show_contextual_link' => TRUE,
+    'show_on_profile' => FALSE,
+    'access_uid' => '',
+    'api_version' => 3,
+  ];
+  return $flags;
+}
+
+
+/**
+ * Private function to send the notifications.
+ *
+ * @param $comment
+ *   The comment array as found in hook_comment $op = publish.
+ */
+function _drurum_comment_notify_mailalert($comment) {
+  module_load_include('inc', 'comment_notify', 'comment_notify');
+
+  $comment = (object) $comment;
+  global $language;
+
+  $nid = $comment->nid;
+  $cid = $comment->cid;
+
+  $uids = array_keys(flag_get_entity_flags('node', $nid, DRURUM_FORUM_TOPIC_SUBSCRIBE_FLAG));
+
+  if ($comment->uid && isset($uids[$comment->uid])) {
+    unset($uids[$comment->uid]);
+  }
+
+  $node = node_load($nid);
+
+
+  foreach ($uids as $uid) {
+    $recipient_user = user_load($uid);
+
+    if (!node_access('view', $node, $recipient_user)) {
+      continue;
+    }
+
+    $mail = $recipient_user->mail;
+
+    $message = [];
+    $user_language = user_preferred_language($recipient_user, $language);
+
+    $raw_values = [
+      'subject' => comment_notify_variable_registry_get('watcher_subject'),
+      'body' => comment_notify_variable_registry_get('comment_notify_default_mailtext'),
+    ];
+
+    foreach ($raw_values as $k => $v) {
+      $message[$k] = token_replace(t($v), [
+        'comment' => $comment,
+
+      ], ['sanitize' => FALSE]);
+    }
+
+    drupal_mail('comment_notify', 'comment_notify_mail', $mail, $user_language, $message);
+
+
+    $user_mail = check_plain($mail);
+
+    // Add an entry to the watchdog log.
+    watchdog(
+      'comment_notify',
+      'Notified: @user_mail',
+      ['@user_mail' => $user_mail],
+      WATCHDOG_NOTICE,
+      l(t('source comment'), 'node/' . $nid, [
+        'fragment' => 'comment-' . $cid,
+      ])
+    );
+  }
+}

--- a/sites/all/modules/custom/drurum/drurum.info
+++ b/sites/all/modules/custom/drurum/drurum.info
@@ -6,3 +6,4 @@ core        = 7.x
 php         = 5.4
 
 scripts[] = js/drurum.js
+files[] = drurum.forum.inc

--- a/sites/all/modules/custom/drurum/drurum.module
+++ b/sites/all/modules/custom/drurum/drurum.module
@@ -15,6 +15,11 @@ define('DRURUM_LOGIN_WHEN_403', 'drurum_login_when_403');
 define('DRURUM_ACTIONS_OVERRIDE', 'drurum_actions_override');
 
 /**
+ * Name of the flag to subscribe to the forum topic
+ */
+define('DRURUM_FORUM_TOPIC_SUBSCRIBE_FLAG', 'forum_subscribe');
+
+/**
  * Implements hook_module_implements_alter().
  */
 function drurum_module_implements_alter(&$implementations, $hook) {
@@ -467,4 +472,29 @@ function drurum_form_node_form_alter(&$form, &$form_state, $form_id) {
     // DO NOT Make the vocabulary required for 'real' forum-nodes.
     $form['taxonomy_forums'][$langcode]['#required'] = FALSE;
   }
+}
+
+/**
+ * Define default flags.
+ */
+function drurum_flag_default_flags() {
+  $flags = _drurum_flag_default_flags();
+  return $flags;
+}
+
+
+/**
+ * Implements hook_comment_update().
+ */
+function drurum_comment_update($comment) {
+  _drurum_comment_notify_mailalert($comment);
+
+}
+
+
+/**
+ * Implements hook_comment_insert().
+ */
+function drurum_comment_insert($comment) {
+  _drurum_comment_notify_mailalert($comment);
 }


### PR DESCRIPTION
#1203

1. Добавлен флаг "forum_subscribe" для подписки на топик.
2.В хуках comment_insert и comment_update организована отправка уведомлений "подписанным" пользователям (кроме автора комментария)