### PR TITLE
Fix HTML5 shiv CDN URL

### DIFF
--- a/profiles/drupalru/themes/druru/theme/system/html.tpl.php
+++ b/profiles/drupalru/themes/druru/theme/system/html.tpl.php
@@ -52,7 +52,7 @@
   <?php print $styles; ?>
   <!-- HTML5 element support for IE6-8 -->
   <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
   <?php print $scripts; ?>
 </head>


### PR DESCRIPTION
The Google Code project hosting service is closed.
Use Cloudflare CDN as working alternative for HTML5 shiv.

#1310